### PR TITLE
Use translation for weather plugin; fix accent

### DIFF
--- a/http-wrapper/ojn_admin/class/translations.fr.php
+++ b/http-wrapper/ojn_admin/class/translations.fr.php
@@ -65,4 +65,8 @@ $translations['Manage Locate requests'] = "Gestion du fichier locate.jsp";
 
 //airquality
 $translations['Air quality plugin'] = "Plugin qualité de l'air";
+
+//weather
+$translations['Weather'] = "Météo";
+
 ?>

--- a/http-wrapper/ojn_admin/help.php
+++ b/http-wrapper/ojn_admin/help.php
@@ -4,7 +4,7 @@ if(!defined('ADMIN_EMAIL'))
 {
 ?>
 Cette fonctionnalité n'est pas activée.
-<?
+<?php
 }
 else
 {
@@ -73,7 +73,7 @@ Description :<textarea name="desc" style="width: 300px; height: 150px"></textare
 <br /><br /><input type="submit" value="Envoyer">
 </form>
 </fieldset>
-<?
+<?php
 }
 require_once "include/append.php";
 ?>

--- a/http-wrapper/ojn_admin/plugins/bunnies/ratp.plugin.php
+++ b/http-wrapper/ojn_admin/plugins/bunnies/ratp.plugin.php
@@ -590,7 +590,7 @@ if(isset($_POST['addReseau']) && $_POST['addReseau'] != ""){
 else{
 ?>
 <input type="text" name="addLigne"><br />
-<?	
+<?php
 }
 ?>
 Arrêt
@@ -605,7 +605,7 @@ if(isset($_POST['addReseau']) && isset($_POST['addLigne']) && $_POST['addLigne']
 else{
 ?>
 <input type="text" name="addArret"><br />
-<?	
+<?php
 }
 ?>
 Direction : 
@@ -620,7 +620,7 @@ if(isset($_POST['addReseau']) && isset($_POST['addLigne']) && $_POST['addLigne']
 else{
 ?>
 <input type="text" name="addArret"><br />
-<?	
+<?php
 }
 if(isset($_POST['addReseau']) && isset($_POST['addLigne']) && $_POST['addLigne'] != ""){
 	echo '<input type="hidden" name="a" value="addStop">';

--- a/server/plugins/weather/plugin_weather.cpp
+++ b/server/plugins/weather/plugin_weather.cpp
@@ -19,7 +19,7 @@
 
 Q_EXPORT_PLUGIN2(plugin_weather, PluginWeather)
 
-PluginWeather::PluginWeather():PluginInterface("weather", "Météo",BunnyZtampPlugin)
+PluginWeather::PluginWeather():PluginInterface("weather", "Weather", BunnyZtampPlugin)
 {
 	std::auto_ptr<QDir> dir(GetLocalHTTPFolder());
 	if(dir.get())


### PR DESCRIPTION
Use translation file for "Météo", which fixes the accent "MÃ..." problem.
Fix bug #36 because of <? instead of <?php