### PR TITLE
[Fix] Cannot login with Php7.

### DIFF
--- a/http-wrapper/ojn_admin/include/common-def.php
+++ b/http-wrapper/ojn_admin/include/common-def.php
@@ -4,7 +4,7 @@ define('ROOT_WWW_ADMIN', 'http://<HOSTNAME>/ojn_admin/');
 define('ROOT_WWW_API', 'http://<HOSTNAME>/ojn_api/');
 define('ADMIN_EMAIL', '<EMAIL>');
 
-session_start('openJabNab');
+session_start(['openJabNab']);
 require_once(ROOT_SITE.'class/api.class.php');
 require_once(ROOT_SITE.'class/template.class.php');
 $ojnAPI = new ojnApi();


### PR DESCRIPTION
      - PHP7 Warning:  session_start() expects parameter 1 to be array